### PR TITLE
docs: simplify README to match org style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,37 @@
-# operator
-// TODO(user): Add simple overview of use/purpose
+# What is Lissto
 
-## Description
-// TODO(user): An in-depth paragraph about your project and overview of use
+Lissto is a DevEnv and DevEx(perience) platform that simplifies the development of applications on Kubernetes.
+It bridges the gap between Compose loved by developers and Kubernetes loved by DevOps and platform engineers.
 
-## Getting Started
+# Lissto Controller
 
-### Prerequisites
-- go version v1.24.0+
-- docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+The Kubernetes controller component of the Lissto platform. Manages Blueprint, Env, and Stack custom resources.
 
-### To Deploy on the cluster
-**Build and push your image to the location specified by `IMG`:**
+## Quick Start
 
-```sh
-make docker-build docker-push IMG=<some-registry>/operator:tag
+Build:
+```bash
+make build
 ```
 
-**NOTE:** This image ought to be published in the personal registry you specified.
-And it is required to have access to pull the image from the working environment.
-Make sure you have the proper permission to the registry if the above commands don’t work.
-
-**Install the CRDs into the cluster:**
-
-```sh
-make install
+Run locally:
+```bash
+make run
 ```
 
-**Deploy the Manager to the cluster with the image specified by `IMG`:**
-
-```sh
-make deploy IMG=<some-registry>/operator:tag
+Deploy to cluster:
+```bash
+make install    # Install CRDs
+make deploy IMG=<registry>/controller:tag
 ```
 
-> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin.
+## Development
 
-**Create instances of your solution**
-You can apply the samples (examples) from the config/sample:
+Run `make help` for all available targets.
 
-```sh
-kubectl apply -k config/samples/
-```
+## Support
 
->**NOTE**: Ensure that the samples has default values to test it out.
-
-### To Uninstall
-**Delete the instances (CRs) from the cluster:**
-
-```sh
-kubectl delete -k config/samples/
-```
-
-**Delete the APIs(CRDs) from the cluster:**
-
-```sh
-make uninstall
-```
-
-**UnDeploy the controller from the cluster:**
-
-```sh
-make undeploy
-```
-
-## Project Distribution
-
-Following the options to release and provide this solution to the users.
-
-### By providing a bundle with all YAML files
-
-1. Build the installer for the image built and published in the registry:
-
-```sh
-make build-installer IMG=<some-registry>/operator:tag
-```
-
-**NOTE:** The makefile target mentioned above generates an 'install.yaml'
-file in the dist directory. This file contains all the resources built
-with Kustomize, which are necessary to install this project without its
-dependencies.
-
-2. Using the installer
-
-Users can just run 'kubectl apply -f <URL for YAML BUNDLE>' to install
-the project, i.e.:
-
-```sh
-kubectl apply -f https://raw.githubusercontent.com/<org>/operator/<tag or branch>/dist/install.yaml
-```
-
-### By providing a Helm Chart
-
-1. Build the chart using the optional helm plugin
-
-```sh
-kubebuilder edit --plugins=helm/v1-alpha
-```
-
-2. See that a chart was generated under 'dist/chart', and users
-can obtain this solution from there.
-
-**NOTE:** If you change the project, you need to update the Helm Chart
-using the same command above to sync the latest changes. Furthermore,
-if you create webhooks, you need to use the above command with
-the '--force' flag and manually ensure that any custom configuration
-previously added to 'dist/chart/values.yaml' or 'dist/chart/manager/manager.yaml'
-is manually re-applied afterwards.
-
-## Contributing
-// TODO(user): Add detailed information on how you would like others to contribute to this project
-
-**NOTE:** Run `make help` for more information on all potential `make` targets
-
-More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
+- Issues: [GitHub Issues](https://github.com/lissto-dev/controller/issues)
 
 ## License
 
@@ -124,4 +40,3 @@ Copyright 2025 Lissto.
 Licensed under the [Sustainable Use License v1.0](LICENSE.md).
 
 For commercial use, please contact: hello@lissto.dev
-


### PR DESCRIPTION
## Summary

Replaced verbose kubebuilder boilerplate README with concise documentation following the pattern used in other lissto-dev repos (api, cli, helm).

## Changes

- Added "What is Lissto" intro section (consistent with other repos)
- Added brief description of the controller component
- Simplified to essential Quick Start commands (build, run, deploy)
- Added Development and Support sections
- Kept License section
- Removed ~100 lines of kubebuilder template text

@daniel-ro can click here to [continue refining the PR](https://app.all-hands.dev/conversations/94b8dea44fdd4af9b28d8367fd8f2c62)