### PR TITLE
fix: tag push image with 'main' on merge to main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,6 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          # Get short commit SHA
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-          
           # Determine if this is a tag build
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
@@ -72,7 +68,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ steps.meta.outputs.is_tag == 'true' && format('{0}:{1}', env.IMAGE_NAME, steps.meta.outputs.tag_name) || format('{0}:{1}', env.IMAGE_NAME, steps.meta.outputs.short_sha) }}
+            ${{ steps.meta.outputs.is_tag == 'true' && format('{0}:{1}', env.IMAGE_NAME, steps.meta.outputs.tag_name) || format('{0}:main', env.IMAGE_NAME) }}
             ${{ steps.meta.outputs.is_stable == 'true' && format('{0}:latest', env.IMAGE_NAME) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -82,7 +78,7 @@ jobs:
           if [[ "${{ steps.meta.outputs.is_tag }}" == "true" ]]; then
             TAG="${{ steps.meta.outputs.tag_name }}"
           else
-            TAG="${{ steps.meta.outputs.short_sha }}"
+            TAG="main"
           fi
           echo "Image Tag: $TAG"
           echo "Is Stable Release: ${{ steps.meta.outputs.is_stable }}"


### PR DESCRIPTION
## Summary

This PR fixes the Docker image tagging for builds triggered by merges to the main branch.

## Changes

- Changed the build workflow to always tag Docker images with `main` instead of the short commit SHA when building from the main branch
- Removed the unused `short_sha` output variable from the metadata extraction step
- Updated the "Show image digest and tag" step to display `main` instead of the short SHA

## Before

When merging to main, images were tagged with the short commit SHA (e.g., `lissto/controller:abc1234`)

## After

When merging to main, images are now tagged with `main` (e.g., `lissto/controller:main`)

Tag builds (e.g., `v1.0.0`) continue to work as before, using the tag name as the image tag.

@daniel-ro can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5eb986207ff64488859a46fbc640df35)